### PR TITLE
Arrow functions lexically binds this.

### DIFF
--- a/src/streams/fetch/index.js
+++ b/src/streams/fetch/index.js
@@ -26,7 +26,7 @@ let FetchStream = (options) => {
 
     listen(this, this[PRIVATE].process.stdout);
 
-    setTimeout(this.endFetch.bind(this), FETCH_TIMEOUT).unref();
+    setTimeout(() => this.endFetch(), FETCH_TIMEOUT).unref();
 };
 
 inherits(FetchStream, Readable);


### PR DESCRIPTION
No need to use `bind`; use a fat arrow instead.
